### PR TITLE
fix(batch): quoted path & remove timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,9 +324,7 @@ To automate this, you can write a batch file somewhere with this content and sav
 
 ```batch
 C:
-cd C:\Program Files\W3Champions\
-start W3Champions.exe
-timeout 5
+start "" "C:\Program Files\W3Champions\W3Champions.exe"
 net stop "Bonjour Service"
 net start "Bonjour Service"
 ```

--- a/W3Champions.bat
+++ b/W3Champions.bat
@@ -1,6 +1,4 @@
 C:
-cd C:\Program Files\W3Champions\
-start W3Champions.exe
-timeout 5
+start "" "C:\Program Files\W3Champions\W3Champions.exe"
 net stop "Bonjour Service"
 net start "Bonjour Service"


### PR DESCRIPTION
When testing this "timeout" was not a recognized command (visible in the lutris)

Furthermore I received an error when trying to either "cd" or "start" a path with spaces in it. 

This change works when I test at least and does not get errors in the lutris log